### PR TITLE
Ballen/transfer docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,30 @@ result to Staging or Production, just run
 ```sh
 make build
 ```
+
+### Updating Transfer API docs
+
+First copy the latest adoc files from the designated koa branch (this
+will vary), for example using rsync:
+
+```sh
+KOA_MANUAL=/koa/doc/manual/
+
+cd "$KOA_MANUAL"
+git fetch
+git checkout -t origin/ballen/doc123
+cd -
+
+rsync -va "$KOA_MANUAL" content/api/transfer/ \
+    --exclude 'private_*' --exclude Makefile
+```
+
+Then run the translation script:
+
+```sh
+scripts/translate_transfer_api_adoc.sh content/api/transfer
+```
+
+Check the git diff, and make sure the menu weights have not changed
+(unless intended) and that nothing else unexpected has changed. Then
+procede with build/deploy.

--- a/content/api/transfer/advanced_endpoint_management.adoc
+++ b/content/api/transfer/advanced_endpoint_management.adoc
@@ -341,12 +341,10 @@ operation to be paused.
   "DATA_TYPE": "pause_rule", 
   "id": 985,
   "message": "Quota exceeded, please delete data from /scratch",
-  "endpoint": "bob#ep1",
-  "user": "eve",
+  "endpoint_id": "339abc22-aab3-4b45-bb56-8d40535bfd80",
   "identity_id": "bbe7b12b-d397-41e3-8895-3b56518302ef",
   "start_time": null,
-  "modified_by": "alice",
-  "modified_by_identity_id": "4c77dd76-aa99-4490-af19-dc81a312c3a1",
+  "modified_by_id": "4c77dd76-aa99-4490-af19-dc81a312c3a1",
   "modified_time": "2015-05-04 16:32:39+00:00"
   "pause_ls": False,
   "pause_mkdir": True,
@@ -387,9 +385,16 @@ operation to be paused.
   special string "now", exact case, is specified, uses the current time on
   the server at the time the request is received.
 
+| endpoint_id
+| string
+| Id of the endpoint to pause new tasks on. Required (for backward
+  compatibility, +endpoint+ can be specified instead, but all code should
+  be updated to use +endpoint_id+).
+
 | endpoint
 | string
-| Canonical name of the endpoint to pause new tasks on. Required.
+| [DEPRECATED] Use +endpoint_id+ instead. Canonical name of the endpoint to
+  pause new tasks on.
 
 | user
 | string
@@ -413,11 +418,11 @@ operation to be paused.
   Note that this field will not be included in the
   link:../task#limited_pause_rule_document[pause_rule_limited]
   documents returned by the get task pause info and get my effective pause rule
-  operations. Use +modified_by_identity_id+ instead. If the modified by
+  operations. Use +modified_by_id+ instead. If the modified by
   identity id is not a globus-id.org identity, this will be the same as
-  the modified_by_identity_id.
+  the +modified_by_id+.
 
-| modified_by_identity_id
+| modified_by_id
 | string
 | Identity id of the identity that last updated or created the pause rule.
   Note that this field will not be included in the
@@ -923,22 +928,23 @@ rights on an endpoint this will return a "PermissionDenied" error.
 === Get task successful transfers as admin
 
 For a "TRANSFER" type task, get a list of files transferred successfully, after
-a task is complete (with +status+ "FAILED" or "SUCCEEDED"). Returns a
-"BadRequest" error if called on a task that is still running or a task that
-is not of type "TRANSFER".
+a task is complete (with +status+ "FAILED" or "SUCCEEDED"), as an endpoint
+admin. See
+link:../task#get_task_successful_transfers[Get task successful transfers]
+(as normal user) for details.
+If the current user has management privileges on only one of the endpoints, the
+paths corresponding to the other endpoint will be "null".
 
 .Authorization
 
 Requires endpoint management privileges on the source or destination endpoint
 of the task. Note that if the user owns the task but does not have management
-privielges on an endpoint this will return a "PermissionDenied" error. If the
-current user has management privileges on only one of the endpoints, the
-paths corresponding to the other endpoint will be "null".
+privileges on an endpoint this will still return a "PermissionDenied" error.
 
 [cols="h,5"]
 |============
 | URL
-| /endpoint_manager/task/<task_id>/successful_transfers
+| /endpoint_manager/task/<task_id>/successful_transfers [?marker=MARKER]
 
 | Method
 | GET
@@ -995,9 +1001,10 @@ manager privileges on. This will include even private endpoints.
 
 .Fields
 * canonical_name
-* user_rule_count (include user and email rules)
+* user_rule_count ("identity" rules)
 * group_rule_count
-* all_rule_count (0 or 1)
+* all_rule_count ("all_authenticated_user" rules)
+* anonymous_rule_count
 
 [cols="h,5"]
 |============
@@ -1018,6 +1025,7 @@ manager privileges on. This will include even private endpoints.
             "user_rule_count": 4,
             "group_rule_count": 1,
             "all_rule_count": 0
+            "anonymous_rule_count": 0
         }
     ]
 }
@@ -1223,20 +1231,21 @@ request will fail with a "PermissionDenied" error.
 
 Get a list of pause rules that the current user can manage. If the result set
 contains over 1000 rules, a +LimitExceeded+ error will be returned and the
-client must pass +filter_endpoint+ to get the rules one endpoint at a time.
+client must pass the +filter_endpoint+ query parameter (with the endpoint id)
+to get the rules one endpoint at a time.
 
 .Authorization
 Returns only rules for which the user has endpoint management rights on. Note
-that rules are always accessible to any user via the
-endpoint link:../endpoint#get_endpoint_pause_rules[Get endpoint pause rules]
-API, but the +created_by+ fields is hidden from non administrators. The purpose
-of this API is to list with the purpose of adding, removing and updating the
-rules, so it only shows rules for which the user has appropriate rights on.
+that rules are always accessible to any user via the endpoint
+link:../endpoint#get_endpoint_pause_rules[Get endpoint pause rules]
+API, but the +modified_by_id+ fields is hidden from non administrators.
+This (admin) API is designed for adding, removing and updating the rules, so
+it only shows rules for which the user has appropriate rights on.
 
 [cols="h,5"]
 |============
 | URL
-| /endpoint_manager/pause_rule_list
+| /endpoint_manager/pause_rule_list [?filter_endpoint=ENDPOINT_ID]
 
 | Method
 | GET
@@ -1313,7 +1322,7 @@ fields (with the +pause_+ prefix) can be updated. It is recommended that
 clients include only the fields to be updated in the request. If non-updatable
 fields are included, they will be ignored.
 
-The +modified_time+ and +modified_by+ fields will be updated based on the
+The +modified_time+ and +modified_by_id+ fields will be updated based on the
 time of the request and the user updating the rule. The response will contain
 these updated fields. Any manual task resume requests made in the past that
 overrode this pause rule will no longer be in effect, and such tasks will

--- a/content/api/transfer/endpoint.adoc
+++ b/content/api/transfer/endpoint.adoc
@@ -163,7 +163,7 @@ sub-documents.
                    Searchable. Optional. Unicode string, max 1024 characters,
                    no new lines. Searchable.
 | keywords       | string
-                 | Comma separated list of alternative names for the endpoint.
+                 | Comma separated list of search keywords for the endpoint.
                    Optional. Unicode string, max 1024 characters. Searchable.
 | name           | string
                  | [DEPRECATED] Legacy friendly name for the endpoint. Limited
@@ -479,8 +479,6 @@ depends entirely on the +host_endpoint+.
                  | See +endpoint+ document.
 | department     | string
                  | See +endpoint+ document.
-| alternatives_names | string
-                 | See +endpoint+ document.
 | description    | string
                  | See +endpoint+ document.
 | endpoint_info_link | string
@@ -685,25 +683,25 @@ Which fields can be updated depends on the type of endpoint:
 | +display_name+, +description+, +public+,
   +default_directory+, +force_encryption+, +disable_verify+,
   +myproxy_server+, +myproxy_dn+, +oauth_server+,
-  +organization+, +department+, +alternative_names+,
+  +organization+, +department+, +keywords+,
   +contact_email+, +contact_info+, +endpoint_info_link+,
   DEPRECATED: +name+/+canonical_name+
 
 | Globus Connect Personal
 | +display_name+, +description+,
-  +organization+, +department+, +alternative_names+,
+  +organization+, +department+, +keywords+,
   +contact_email+, +contact_info+, +endpoint_info_link+
   DEPRECATED: +name+/+canonical_name+
 
 | Shared endpoint
 | +display_name+, +description+,
-  +organization+, +department+, +alternative_names+,
+  +organization+, +department+, +keywords+,
   +contact_email+, +contact_info+, +endpoint_info_link+
   DEPRECATED: +name+/+canonical_name+
 
 | S3 endpoint
 | +display_name+, +description+,
-  +organization+, +department+, +alternative_names+,
+  +organization+, +department+, +keywords+,
   +contact_email+, +contact_info+, +endpoint_info_link+
   DEPRECATED: +name+/+canonical_name+
 |============

--- a/content/api/transfer/index.adoc
+++ b/content/api/transfer/index.adoc
@@ -45,11 +45,14 @@ library in scripting languages like Python and Ruby.
 
 == Mailing List
 
-The
-link:http://lists.globusonline.org/mailman/listinfo/transfer-api[mailing list]
-is the best place to get help using the Transfer API. Announcements about new
-features and deprecations are also sent to the list, so all users of the API
-are encouraged to subscribe.
+The link:https://www.globus.org/mailing-lists[developer-discuss@globus.org]
+mailing list is the best place to get help using the Transfer API.
+Announcements about new features and deprecations are also sent to the list, so
+all users of the API are encouraged to subscribe.
+
+NOTE: The developer-discuss@globus.org list replaces the old transfer-api list.
+The archives for the old list may still be useful, and is available and
+searchable link:http://lists.globusonline.org/pipermail/transfer-api/[here].
 
 == Example Clients
 

--- a/content/api/transfer/task.adoc
+++ b/content/api/transfer/task.adoc
@@ -416,13 +416,6 @@ continue to work.
             "label": null,
             "subtasks_total": 10,
             "nice_status_expires_in": 123,
-            "subtask_link": {
-                "href": "task/12345678-9abc-def0-1234-56789abcde03/subtask_list?format=json",
-                "resource": "subtask list",
-                "DATA_TYPE": "link",
-                "rel": "child",
-                "title": "child subtask list"
-            },
             "status": "ACTIVE",
             "bytes_checksummed": 10,
             "subtasks_failed": 10,
@@ -432,13 +425,6 @@ continue to work.
             "nice_status_short_description": null,
             "preserve_timestamp": false,
             "task_id": "12345678-9abc-def0-1234-56789abcde03",
-            "event_link": {
-                "href": "task/12345678-9abc-def0-1234-56789abcde03/event_list?format=json",
-                "resource": "event list",
-                "DATA_TYPE": "link",
-                "rel": "child",
-                "title": "child event list"
-            },
             "encrypt_data": false,
             "source_endpoint": "bob#laptop",
             "subtasks_succeeded": 10,
@@ -673,6 +659,65 @@ Get only error events.
   error will be returned.
 
 |===================
+
+
+[[get_task_successful_transfers]]
+=== Get task successful transfers
+
+For "TRANSFER" tasks that are completed (have +status+ "SUCCEEDED" or
+"FAILED"), get a list of files that were successfully transferred. The list
+includes the source and destination paths of each file. Note that this does not
+include files that were checked but skipped as part of a sync transfer, only
+files that were actually transferred, and does not include any directories.
+
+A result set may be too large to fit into a single response. In this case, the
+response will have the +next_marker+ field set to a non-empty, opaque integer
+token. Pass this token as the +marker+ query parameter in another request to
+get the next chunk of data. A client must not attempt to generate or assume
+knowledge of a marker's format. Note that this differs from the offset based
+paging supported by some other resources.
+
+Returns 404 "ClientError.NotFound" if history has been deleted (history is
+kept for only one month ). Returns 400 "ClientError.BadRequest" if the
+task is not yet complete or is not of type "TRANSFER".
+
+NOTE: The paths are relative to the shared endpoint root, as submitted in
+the transfer request, not relative to the host endpoint root.
+
+[cols="h,5"]
+|============
+| URL
+| /task/<task_id>/successful_transfers [?marker=MARKER]
+
+| Method
+| GET
+
+| Response Body a| 
+-------------------------------------------------------------------
+{
+  "DATA_TYPE": "successful_transfers",
+  "marker": 0
+  "next_marker": null,
+  "DATA": [
+    {
+      "DATA_TYPE": "successful_transfer",
+      "source_path": "/share/godata/file1.txt"
+      "destination_path": "/~/test_godata_copy/file1.txt",
+    },
+    {
+      "DATA_TYPE": "successful_transfer",
+      "source_path": "/share/godata/file2.txt"
+      "destination_path": "/~/test_godata_copy/file2.txt",
+    },
+    {
+      "DATA_TYPE": "successful_transfer",
+      "source_path": "/share/godata/file3.txt"
+      "destination_path": "/~/test_godata_copy/file3.txt",
+    }
+  ],
+}
+-------------------------------------------------------------------
+|============
 
 
 [[get_task_pause_info]]

--- a/scripts/translate_transfer_api_adoc.sh
+++ b/scripts/translate_transfer_api_adoc.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-set -e
 
 if [ $# -ne 1 ]; then
     echo "Usage: $0 path/to/content/api/transfer"
@@ -15,6 +14,9 @@ else
     # OS X / BSD sed
     SED_OPTS="-i '' -e"
 fi
+
+# NB: set after sed check
+set -e
 
 DOC_DIR="$1"
 

--- a/scripts/translate_transfer_api_adoc.sh
+++ b/scripts/translate_transfer_api_adoc.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+
+set -e
+
+if [ $# -ne 1 ]; then
+    echo "Usage: $0 path/to/content/api/transfer"
+    exit 1
+fi
+
+DOC_DIR="$1"
+
+TOC='toc\:\
+\:toclevels\: 3\
+\:numbered\:'
+
+# menu_weight vars
+
+# overview
+O='---\
+menu_weight: 0\
+---\
+\
+= /'
+# endpoint acivation
+EA='---\
+menu_weight: 1\
+---\
+\
+= /'
+# task submission
+TS='---\
+menu_weight: 2\
+---\
+\
+= /'
+# task management
+TASK='---\
+menu_weight: 3\
+---\
+\
+= /'
+# file operations
+FO='---\
+menu_weight: 4\
+---\
+\
+= /'
+# endpoint management
+EM='---\
+menu_weight: 5\
+---\
+\
+= /'
+# endpoint search
+ES='---\
+menu_weight: 6\
+---\
+\
+= /'
+# endpoint roles
+ER='---\
+menu_weight: 7\
+---\
+\
+= /'
+# endpoint bookmarks
+EB='---\
+menu_weight: 8\
+---\
+\
+= /'
+# endpoint acl management
+ACL='---\
+menu_weight: 9\
+---\
+\
+= /'
+# advanced endpoint management
+AEM='---\
+menu_weight: 10\
+---\
+\
+= /'
+# changelog
+CH='---\
+menu_weight: 12\
+---\
+\
+= /'
+
+echo "Performing seds inline on files..."
+sed -i -e 's/----\n/----terminal/g' $DOC_DIR/*.adoc
+sed -i -e 's/\*\([a-z]*\)\(([0-9])\)\*/link:..\/\1[\*\1\2\*]/g' $DOC_DIR/*.adoc
+#sed -i -e 's/link:(.*?)\{outfilesuffix\}/link:(.*?)/g' $DOC_DIR/*.adoc
+#sed -i -e 's/link:\([a-z]*\){outfilesuffix}/link:..\/\1/g' $DOC_DIR/*.adoc
+#sed -i -e 's/link:\([a-z]*_[a-z]*\){outfilesuffix}/link:..\/\1/g' $DOC_DIR/*.adoc
+sed -i -e 's/link:\([a-z]*[0-9]*_*[a-z]*[0-9]*_*[a-z]*[0-9]*_*[a-z]*[0-9]*\){outfilesuffix}/link:..\/\1/g' $DOC_DIR/*.adoc
+sed -i -e 's/link:..\//link:/g' $DOC_DIR/index.adoc
+#sed -i -e 's/{outfilesuffix}//g' $DOC_DIR/*.adoc
+sed -i -e "s/toc2\:/${TOC}/g" $DOC_DIR/*.adoc
+#sed -i -e '1i\some string\n' $DOC_DIR/acl.adoc
+sed -i -e 's/\:numbered\://g' $DOC_DIR/change_history.adoc
+
+#add menu_weights
+sed -i -e "s/^\= /${ACL}" $DOC_DIR/acl.adoc
+sed -i -e "s/^\= /${AEM}" $DOC_DIR/advanced_endpoint_management.adoc
+sed -i -e "s/^\= /${CH}" $DOC_DIR/change_history.adoc
+sed -i -e "s/^\= /${EA}" $DOC_DIR/endpoint_activation.adoc
+sed -i -e "s/^\= /${EB}" $DOC_DIR/endpoint_bookmarks.adoc
+sed -i -e "s/^\= /${ER}" $DOC_DIR/endpoint_roles.adoc
+sed -i -e "s/^\= /${ES}" $DOC_DIR/endpoint_search.adoc
+sed -i -e "s/^\= /${EM}" $DOC_DIR/endpoint.adoc
+sed -i -e "s/^\= /${FO}" $DOC_DIR/file_operations.adoc
+sed -i -e "s/^\= /${O}" $DOC_DIR/overview.adoc
+sed -i -e "s/^\= /${TS}" $DOC_DIR/task_submit.adoc
+sed -i -e "s/^\= /${TASK}" $DOC_DIR/task.adoc

--- a/scripts/translate_transfer_api_adoc.sh
+++ b/scripts/translate_transfer_api_adoc.sh
@@ -1,22 +1,11 @@
 #!/bin/bash
 
+set -e
 
 if [ $# -ne 1 ]; then
     echo "Usage: $0 path/to/content/api/transfer"
     exit 1
 fi
-
-sed --version 2>&1 | grep -q GNU
-if [ $? -eq 0 ]; then
-    # GNU sed
-    SED_OPTS="-i -e"
-else
-    # OS X / BSD sed
-    SED_OPTS="-i '' -e"
-fi
-
-# NB: set after sed check
-set -e
 
 DOC_DIR="$1"
 
@@ -100,28 +89,30 @@ menu_weight: 12\
 = /'
 
 echo "Performing seds inline on files..."
-sed $SED_OPTS 's/----\n/----terminal/g' $DOC_DIR/*.adoc
-sed $SED_OPTS 's/\*\([a-z]*\)\(([0-9])\)\*/link:..\/\1[\*\1\2\*]/g' $DOC_DIR/*.adoc
-#sed $SED_OPTS 's/link:(.*?)\{outfilesuffix\}/link:(.*?)/g' $DOC_DIR/*.adoc
-#sed $SED_OPTS 's/link:\([a-z]*\){outfilesuffix}/link:..\/\1/g' $DOC_DIR/*.adoc
-#sed $SED_OPTS 's/link:\([a-z]*_[a-z]*\){outfilesuffix}/link:..\/\1/g' $DOC_DIR/*.adoc
-sed $SED_OPTS 's/link:\([a-z]*[0-9]*_*[a-z]*[0-9]*_*[a-z]*[0-9]*_*[a-z]*[0-9]*\){outfilesuffix}/link:..\/\1/g' $DOC_DIR/*.adoc
-sed $SED_OPTS 's/link:..\//link:/g' $DOC_DIR/index.adoc
-#sed $SED_OPTS 's/{outfilesuffix}//g' $DOC_DIR/*.adoc
-sed $SED_OPTS "s/toc2\:/${TOC}/g" $DOC_DIR/*.adoc
-#sed $SED_OPTS '1i\some string\n' $DOC_DIR/acl.adoc
-sed $SED_OPTS 's/\:numbered\://g' $DOC_DIR/change_history.adoc
+sed -i.bak -e 's/----\n/----terminal/g' $DOC_DIR/*.adoc
+sed -i.bak -e 's/\*\([a-z]*\)\(([0-9])\)\*/link:..\/\1[\*\1\2\*]/g' $DOC_DIR/*.adoc
+#sed -i.bak -e 's/link:(.*?)\{outfilesuffix\}/link:(.*?)/g' $DOC_DIR/*.adoc
+#sed -i.bak -e 's/link:\([a-z]*\){outfilesuffix}/link:..\/\1/g' $DOC_DIR/*.adoc
+#sed -i.bak -e 's/link:\([a-z]*_[a-z]*\){outfilesuffix}/link:..\/\1/g' $DOC_DIR/*.adoc
+sed -i.bak -e 's/link:\([a-z]*[0-9]*_*[a-z]*[0-9]*_*[a-z]*[0-9]*_*[a-z]*[0-9]*\){outfilesuffix}/link:..\/\1/g' $DOC_DIR/*.adoc
+sed -i.bak -e 's/link:..\//link:/g' $DOC_DIR/index.adoc
+#sed -i.bak -e 's/{outfilesuffix}//g' $DOC_DIR/*.adoc
+sed -i.bak -e "s/toc2\:/${TOC}/g" $DOC_DIR/*.adoc
+#sed -i.bak -e '1i\some string\n' $DOC_DIR/acl.adoc
+sed -i.bak -e 's/\:numbered\://g' $DOC_DIR/change_history.adoc
 
 #add menu_weights
-sed $SED_OPTS "s/^\= /${ACL}" $DOC_DIR/acl.adoc
-sed $SED_OPTS "s/^\= /${AEM}" $DOC_DIR/advanced_endpoint_management.adoc
-sed $SED_OPTS "s/^\= /${CH}" $DOC_DIR/change_history.adoc
-sed $SED_OPTS "s/^\= /${EA}" $DOC_DIR/endpoint_activation.adoc
-sed $SED_OPTS "s/^\= /${EB}" $DOC_DIR/endpoint_bookmarks.adoc
-sed $SED_OPTS "s/^\= /${ER}" $DOC_DIR/endpoint_roles.adoc
-sed $SED_OPTS "s/^\= /${ES}" $DOC_DIR/endpoint_search.adoc
-sed $SED_OPTS "s/^\= /${EM}" $DOC_DIR/endpoint.adoc
-sed $SED_OPTS "s/^\= /${FO}" $DOC_DIR/file_operations.adoc
-sed $SED_OPTS "s/^\= /${O}" $DOC_DIR/overview.adoc
-sed $SED_OPTS "s/^\= /${TS}" $DOC_DIR/task_submit.adoc
-sed $SED_OPTS "s/^\= /${TASK}" $DOC_DIR/task.adoc
+sed -i.bak -e "s/^\= /${ACL}" $DOC_DIR/acl.adoc
+sed -i.bak -e "s/^\= /${AEM}" $DOC_DIR/advanced_endpoint_management.adoc
+sed -i.bak -e "s/^\= /${CH}" $DOC_DIR/change_history.adoc
+sed -i.bak -e "s/^\= /${EA}" $DOC_DIR/endpoint_activation.adoc
+sed -i.bak -e "s/^\= /${EB}" $DOC_DIR/endpoint_bookmarks.adoc
+sed -i.bak -e "s/^\= /${ER}" $DOC_DIR/endpoint_roles.adoc
+sed -i.bak -e "s/^\= /${ES}" $DOC_DIR/endpoint_search.adoc
+sed -i.bak -e "s/^\= /${EM}" $DOC_DIR/endpoint.adoc
+sed -i.bak -e "s/^\= /${FO}" $DOC_DIR/file_operations.adoc
+sed -i.bak -e "s/^\= /${O}" $DOC_DIR/overview.adoc
+sed -i.bak -e "s/^\= /${TS}" $DOC_DIR/task_submit.adoc
+sed -i.bak -e "s/^\= /${TASK}" $DOC_DIR/task.adoc
+
+rm $DOC_DIR/*.adoc.bak

--- a/scripts/translate_transfer_api_adoc.sh
+++ b/scripts/translate_transfer_api_adoc.sh
@@ -7,6 +7,15 @@ if [ $# -ne 1 ]; then
     exit 1
 fi
 
+sed --version 2>&1 | grep -q GNU
+if [ $? -eq 0 ]; then
+    # GNU sed
+    SED_OPTS="-i -e"
+else
+    # OS X / BSD sed
+    SED_OPTS="-i '' -e"
+fi
+
 DOC_DIR="$1"
 
 TOC='toc\:\
@@ -89,28 +98,28 @@ menu_weight: 12\
 = /'
 
 echo "Performing seds inline on files..."
-sed -i -e 's/----\n/----terminal/g' $DOC_DIR/*.adoc
-sed -i -e 's/\*\([a-z]*\)\(([0-9])\)\*/link:..\/\1[\*\1\2\*]/g' $DOC_DIR/*.adoc
-#sed -i -e 's/link:(.*?)\{outfilesuffix\}/link:(.*?)/g' $DOC_DIR/*.adoc
-#sed -i -e 's/link:\([a-z]*\){outfilesuffix}/link:..\/\1/g' $DOC_DIR/*.adoc
-#sed -i -e 's/link:\([a-z]*_[a-z]*\){outfilesuffix}/link:..\/\1/g' $DOC_DIR/*.adoc
-sed -i -e 's/link:\([a-z]*[0-9]*_*[a-z]*[0-9]*_*[a-z]*[0-9]*_*[a-z]*[0-9]*\){outfilesuffix}/link:..\/\1/g' $DOC_DIR/*.adoc
-sed -i -e 's/link:..\//link:/g' $DOC_DIR/index.adoc
-#sed -i -e 's/{outfilesuffix}//g' $DOC_DIR/*.adoc
-sed -i -e "s/toc2\:/${TOC}/g" $DOC_DIR/*.adoc
-#sed -i -e '1i\some string\n' $DOC_DIR/acl.adoc
-sed -i -e 's/\:numbered\://g' $DOC_DIR/change_history.adoc
+sed $SED_OPTS 's/----\n/----terminal/g' $DOC_DIR/*.adoc
+sed $SED_OPTS 's/\*\([a-z]*\)\(([0-9])\)\*/link:..\/\1[\*\1\2\*]/g' $DOC_DIR/*.adoc
+#sed $SED_OPTS 's/link:(.*?)\{outfilesuffix\}/link:(.*?)/g' $DOC_DIR/*.adoc
+#sed $SED_OPTS 's/link:\([a-z]*\){outfilesuffix}/link:..\/\1/g' $DOC_DIR/*.adoc
+#sed $SED_OPTS 's/link:\([a-z]*_[a-z]*\){outfilesuffix}/link:..\/\1/g' $DOC_DIR/*.adoc
+sed $SED_OPTS 's/link:\([a-z]*[0-9]*_*[a-z]*[0-9]*_*[a-z]*[0-9]*_*[a-z]*[0-9]*\){outfilesuffix}/link:..\/\1/g' $DOC_DIR/*.adoc
+sed $SED_OPTS 's/link:..\//link:/g' $DOC_DIR/index.adoc
+#sed $SED_OPTS 's/{outfilesuffix}//g' $DOC_DIR/*.adoc
+sed $SED_OPTS "s/toc2\:/${TOC}/g" $DOC_DIR/*.adoc
+#sed $SED_OPTS '1i\some string\n' $DOC_DIR/acl.adoc
+sed $SED_OPTS 's/\:numbered\://g' $DOC_DIR/change_history.adoc
 
 #add menu_weights
-sed -i -e "s/^\= /${ACL}" $DOC_DIR/acl.adoc
-sed -i -e "s/^\= /${AEM}" $DOC_DIR/advanced_endpoint_management.adoc
-sed -i -e "s/^\= /${CH}" $DOC_DIR/change_history.adoc
-sed -i -e "s/^\= /${EA}" $DOC_DIR/endpoint_activation.adoc
-sed -i -e "s/^\= /${EB}" $DOC_DIR/endpoint_bookmarks.adoc
-sed -i -e "s/^\= /${ER}" $DOC_DIR/endpoint_roles.adoc
-sed -i -e "s/^\= /${ES}" $DOC_DIR/endpoint_search.adoc
-sed -i -e "s/^\= /${EM}" $DOC_DIR/endpoint.adoc
-sed -i -e "s/^\= /${FO}" $DOC_DIR/file_operations.adoc
-sed -i -e "s/^\= /${O}" $DOC_DIR/overview.adoc
-sed -i -e "s/^\= /${TS}" $DOC_DIR/task_submit.adoc
-sed -i -e "s/^\= /${TASK}" $DOC_DIR/task.adoc
+sed $SED_OPTS "s/^\= /${ACL}" $DOC_DIR/acl.adoc
+sed $SED_OPTS "s/^\= /${AEM}" $DOC_DIR/advanced_endpoint_management.adoc
+sed $SED_OPTS "s/^\= /${CH}" $DOC_DIR/change_history.adoc
+sed $SED_OPTS "s/^\= /${EA}" $DOC_DIR/endpoint_activation.adoc
+sed $SED_OPTS "s/^\= /${EB}" $DOC_DIR/endpoint_bookmarks.adoc
+sed $SED_OPTS "s/^\= /${ER}" $DOC_DIR/endpoint_roles.adoc
+sed $SED_OPTS "s/^\= /${ES}" $DOC_DIR/endpoint_search.adoc
+sed $SED_OPTS "s/^\= /${EM}" $DOC_DIR/endpoint.adoc
+sed $SED_OPTS "s/^\= /${FO}" $DOC_DIR/file_operations.adoc
+sed $SED_OPTS "s/^\= /${O}" $DOC_DIR/overview.adoc
+sed $SED_OPTS "s/^\= /${TS}" $DOC_DIR/task_submit.adoc
+sed $SED_OPTS "s/^\= /${TASK}" $DOC_DIR/task.adoc


### PR DESCRIPTION
This has two changes:

1. Script with sed commands from koa_update_tapi.sh, and corresponding readme section.
2. Latest doc update.

@teresas can you take a look? I'd like to use this new script as the place to put any further sed or other transformations, so anyone can run it. You should be able to call it from your existing scripts, and remove all the inline sed stuff.

I'd like to get the doc changes onto staging and prod ASAP, but I don't want to interfere with anything else that is going on. It looks like the strategy is to have feature branches, and merge/deploy them first to staging, make sure they look ok, then merge/deploy them to prod?