### PR TITLE
Include effect of client_id on Auth helper pages

### DIFF
--- a/content/api/helper-pages/auth.adoc
+++ b/content/api/helper-pages/auth.adoc
@@ -23,7 +23,8 @@ query parameters:
 Passing client_id will make the logout page header "Logged out of
 <client-display-name>". For example, if the client display name that was
 registered with Globus Auth for the specified <client-id> is "Example
-App", the logout page header will be "Logged out of Example App"
+App", the logout page header will be "Logged out of Example App". This
+parameter will also apply branding associated with the client, if any.
 
 If redirect_uri and redirect_name parameters are provided, the bottom of
 the logout page will display "Continue to <link-text>", which is linked
@@ -41,6 +42,8 @@ query parameters:
 * redirect_uri=<http-url>
 * redirect_name=<link-text>
 
+Passing client_id will apply branding associated with the client, if any.
+
 If redirect_uri and redirect_name parameters are provided, the top of
 the identities page will display "Return to <link-text>", which is linked
 to <http-url>.
@@ -57,6 +60,8 @@ query parameters:
 * client_id=<client-id>
 * redirect_uri=<http-url>
 * redirect_name=<link-text>
+
+Passing client_id will apply branding associated with the client, if any.
 
 If redirect_uri and redirect_name parameters are provided, the top of
 the consents page will display "Return to <link-text>", which is linked


### PR DESCRIPTION
Adds a very brief mention in each of the three Auth helper page descriptions about how `client_id` will affect the branding of the page.

Fixes #72.