### PR TITLE
Update google drive docs

### DIFF
--- a/content/premium-storage-connectors/google-drive.adoc
+++ b/content/premium-storage-connectors/google-drive.adoc
@@ -7,7 +7,7 @@ menu_weight: 1
 = Google Drive Connector (beta)
 :toc:
 :toc-placement: manual
-:revdate: April 6, 2017
+:revdate: May 15, 2017
 
 [doc-info]*Last Updated: {revdate}*
 
@@ -28,15 +28,19 @@ You must have a Google account to complete this step.
 ** https://console.developers.google.com/iam-admin/projects
 . Click "Create Project" button
 . After creating the project, Click on the "Credentials" menu, then click on the "Create Credentials" button and select the "OAuth client ID" option.
-. Configure the Consent screen
+. Configure the Consent screen.
 . When prompted, choose "Web application" as the Application type.
+. When naming the application be sure to choose a name that is descriptive so users will recognize the application.
 ** Make very careful note of the Google Client ID and Google Client Secret you get in this step.
+IMPORTANT: A set of Google credentials can only be used with a single GCSv5 installation. If you wish to install multiple instances you must create a new Google application for each one.
 . Configure an entry for "Authorized redirect URIs" as follows:
 ** +++https://YOUR_SERVER_FQDN_HOSTNAME/api/v1/authcallback_google+++
 ** The "YOUR_SERVER_FQDN_HOSTNAME" value must be:
-*** Resolvable in public DNS
-*** The value that the [GCS Manager].ServerName option is / will be set to in the globus-connect-server.conf file
+*** Resolvable in public DNS.
+*** The value that the [GCS Manager].ServerName option is / will be set to in the globus-connect-server.conf file.
 . You must now enable the Drive API for your project before it can be used. Click on the "Library" menu for your project, and then click on the "Drive API" link. After that, press the "Enable" button to enable the DriveAPI for your project.
+
+TIP: You may wish to provide instructions for your users on how to disconnect this Google application from their accounts. They may do so by visiting https://myaccount.google.com and clicking on the "Connect apps & sites" link.
 
 == Configure your GCSv5 endpoint to use the Google Drive Connector 
 This section requires that a Globus Connect Server v5 endpoint has been setup and is functional. The basic installation of GCSv5 sets it up for POSIX file systems so basic testing of the installation can be done. 


### PR DESCRIPTION
* Advise that a set of Google credentials may only be used with a single GCSv5 installation.
* Suggest that application name be descriptive enough so that users can identify it.
* Instructions on how to users may revoke consent for the Google application.